### PR TITLE
TunnelEp Changes for VPP Renderer

### DIFF
--- a/src/VppUplink.cpp
+++ b/src/VppUplink.cpp
@@ -167,6 +167,16 @@ Uplink::local_address() const
     return m_pfx.address();
 }
 
+const std::string
+Uplink::uplink_l2_address() const
+{
+    const std::string str("");
+    if (m_uplink) {
+        return m_uplink->l2_address().to_string();
+    }
+    return str;
+}
+
 const std::shared_ptr<interface>
 Uplink::local_interface() const
 {

--- a/src/include/VppRenderer.hpp
+++ b/src/include/VppRenderer.hpp
@@ -18,6 +18,7 @@
 #include <opflex/ofcore/OFFramework.h>
 #include <opflexagent/IdGenerator.h>
 #include <opflexagent/Renderer.h>
+#include <opflexagent/TunnelEpManager.h>
 
 #include <vom/hw.hpp>
 
@@ -57,6 +58,23 @@ class VppRenderer : public opflexagent::Renderer
     virtual void start();
     virtual void stop();
 
+    /**
+     * Is uplink address owned by renderer
+     */
+    virtual bool isUplinkAddressImplemented() {
+        return true;
+    }
+
+    /**
+     * Get uplink address from renderer
+     */
+    virtual std::string getUplinkAddress();
+
+    /**
+     * Get uplink l2 address from renderer
+     */
+    virtual std::string getUplinkMac();
+
   private:
     /**
      * The socket used for inspecting the state built in VPP-manager
@@ -72,6 +90,17 @@ class VppRenderer : public opflexagent::Renderer
      * Single instance of the VPP manager
      */
     VppManager *vppManager;
+
+    /**
+     * Opflex Tunnel EP Manager
+     */
+    TunnelEpManager tunnelEpManager;
+
+    std::string uplinkIface;
+    uint16_t uplinkVlan;
+
+    enum EncapType { encapTypeNone, encapTypeVlan, encapTypeVxlan, encapTypeIvxlan };
+    EncapType encapType;
 
     /**
      * has this party started.

--- a/src/include/VppUplink.hpp
+++ b/src/include/VppUplink.hpp
@@ -91,7 +91,7 @@ class Uplink : public dhcp_client::event_listener
 
     const boost::asio::ip::address &local_address() const;
     const std::shared_ptr<interface> local_interface() const;
-
+    const std::string uplink_l2_address() const;
     /**
      * Handle notifications about DHCP complete
      */


### PR DESCRIPTION
Use ivxlan encap in renderer config file.
Start TunnelEpManager from VPP Renderer
Implement renderer interfaces isUplinkAddressImplemented()
getUplinkAddress() and getUplinkMac().

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>